### PR TITLE
Fix image reference

### DIFF
--- a/8/php7/debian9/apache/Dockerfile
+++ b/8/php7/debian9/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-marketplace-ops/php7-apache:7.3-debian9
+FROM marketplace.gcr.io/google/php7-apache2:7.3
 
 RUN set -ex; \
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/versions.yaml
+++ b/versions.yaml
@@ -19,7 +19,7 @@ cloudbuild:
   enable_parallel: false
 versions:
 - dir: 8/php7/debian9/apache
-  from: gcr.io/cloud-marketplace-ops/php7-apache:7.3-debian9
+  from: marketplace.gcr.io/google/php7-apache2:7.3
   packages:
     composer:
       gpg: 1f210b9037fcf82670d75892dfc44400f13fe9ada7af9e787f93e50e3b764111


### PR DESCRIPTION
Previously used images based on cloud-marketplace-ops GCP project was not publicly accessible for end-users.